### PR TITLE
Refactor game structure and improve cell management

### DIFF
--- a/src/Cell.hpp
+++ b/src/Cell.hpp
@@ -16,9 +16,16 @@ struct Cell : public sf::Drawable
 {
 	static constexpr unsigned SIZE = 50u;
 
+	Cell() :
+		shape(sf::Vector2f(SIZE, SIZE)),
+		isFilled(false)
+	{
+		shape.setFillColor(sf::Color::Black);
+		shape.setOutlineThickness(1.f);
+		shape.setOutlineColor(sf::Color::White);
+	}
 	inline void draw(sf::RenderTarget& target, sf::RenderStates states) const override { target.draw(shape, states); }
 
 	sf::RectangleShape shape;
-	sf::Color color;
-	bool isFilled = false;
+	bool isFilled;
 };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -11,20 +11,34 @@
 #include "Utility.hpp"
 
 Game::Game() :
-	gameState(GameState::TitleScreen),
+	gameState(GameState::InGame),
 	isPaused(false)
 {
 	initializeWindow();
 }
 
-void Game::run()
+int Game::run()
 {
+	const float FIXED_TIME_STEP = 1.f / 60.f; // Fixed time step per update
+	sf::Clock clock;						  // Clock to measure time
+	float timeSinceLastUpdate = 0.f;		  // Time accumulator for fixed timestep
+	float interpolationFactor = 0.f;		  // Interpolation factor for rendering
+
 	while (window.isOpen())
 	{
+		timeSinceLastUpdate += clock.restart().asSeconds();
 		processInput();
-		update();
+
+		while (timeSinceLastUpdate >= FIXED_TIME_STEP)
+		{
+			update(FIXED_TIME_STEP);
+			timeSinceLastUpdate -= FIXED_TIME_STEP;
+		}
+
+		interpolationFactor = timeSinceLastUpdate / FIXED_TIME_STEP;
 		render();
 	}
+	return 0;
 }
 
 void Game::processInput()
@@ -58,7 +72,7 @@ void Game::processInput()
 	}
 }
 
-void Game::update()
+void Game::update(float fixedTimeStep)
 {
 	switch (gameState)
 	{
@@ -91,7 +105,7 @@ void Game::render()
 	}
 	{
 	case GameState::InGame:
-
+		window.draw(grid);
 		break;
 	}
 	{

--- a/src/Game.hpp
+++ b/src/Game.hpp
@@ -15,15 +15,15 @@
 class Game
 {
 public:
-	static constexpr unsigned WINDOW_WIDTH = 800U;
-	static constexpr unsigned WINDOW_HEIGHT = 1200U;
+	static constexpr unsigned WINDOW_WIDTH = 850U;
+	static constexpr unsigned WINDOW_HEIGHT = 1100U;
 
 	Game();
-	void run();
+	int run();
 
 private:
 	void processInput();
-	void update();
+	void update(float fixedTimeStep);
 	void render();
 
 	void initializeWindow();
@@ -36,8 +36,6 @@ private:
 	};
 	GameState gameState;
 	bool isPaused;
-
-	sf::Clock clock;
 
 	sf::RenderWindow window;
 	Grid grid;

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -9,19 +9,15 @@
 
 #include "Grid.hpp"
 
-Grid::Grid()
+Grid::Grid() :
+	offset({ 50U, 50U })
 {
 	cells.resize(HEIGHT, std::vector<Cell>(WIDTH));
 	for (unsigned y = 0; y < HEIGHT; ++y)
 	{
 		for (unsigned x = 0; x < WIDTH; ++x)
 		{
-			cells[y][x].shape.setSize(sf::Vector2f(Cell::SIZE, Cell::SIZE));
-			cells[y][x].shape.setPosition(sf::Vector2f(y * Cell::SIZE, x * Cell::SIZE));
-			cells[y][x].shape.setFillColor(sf::Color::Black);
-			cells[y][x].shape.setOutlineThickness(1.f);
-			cells[y][x].shape.setOutlineColor(sf::Color::White);
-			cells[y][x].isFilled = false;
+			cells[y][x].shape.setPosition(sf::Vector2f(x * Cell::SIZE + offset.x, y * Cell::SIZE + offset.y));
 		}
 	}
 }
@@ -32,7 +28,7 @@ void Grid::draw(sf::RenderTarget& target, sf::RenderStates states) const
 	{
 		for (unsigned x = 0; x < WIDTH; ++x)
 		{
-			target.draw(cells[y][x].shape, states);
+			target.draw(cells[y][x].shape);
 		}
 	}
 }

--- a/src/Grid.hpp
+++ b/src/Grid.hpp
@@ -22,5 +22,6 @@ public:
 	void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
 private:
+	sf::Vector2u offset;
 	std::vector<std::vector<Cell>> cells;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,5 @@
 int main()
 {
 	Game game;
-	game.run();
-	return 0;
+	return game.run();
 }


### PR DESCRIPTION
- Added constructor to `Cell` class for initialization, moving cell initialization from `Grid` to `Cell`.
- Updated `Game` constructor to set initial state to `InGame` until I deal with state changes.
- Changed `run` method to return an integer and made `main` return `game.run()`.
- Implemented fixed timestep update game loop.
- Adjusted window dimensions in `Game.hpp`.
- Added `Grid` rendering.